### PR TITLE
MMK_S_DCL was already defined.  However, it also now tests for version

### DIFF
--- a/build_target.c
+++ b/build_target.c
@@ -12,6 +12,7 @@
 **  AUTHOR: 	    M. Madison
 **
 **  Copyright (c) 2008, Matthew Madison.
+**  Copyright (c) 2012, Endless Software Solutions.
 **  
 **  All rights reserved.
 **  
@@ -88,9 +89,12 @@
 **  	23-MAR-1997 V2.5-1  Madison 	Set symbol MMS$STATUS to action status.
 **  	07-SEP-1998 V2.5-2  Madison 	Fix endless loop on long cmd tokens.
 **  	27-DEC-1998 V2.6    Madison 	Prototype cleanup.
+**  	14-JUL-2012 V2.7    Sneddon 	github issue #1: add support for
+**					  extended DCL command line. Thanks to
+**					  Craig A. Berry.
 **--
 */
-#pragma module BUILD_TARGET "V2.6"
+#pragma module BUILD_TARGET "V2.7"
 #include "mmk.h"
 #include "globals.h"
 #include <rmsdef.h>
@@ -984,15 +988,15 @@ static unsigned int send_cmd_and_wait (SPHANDLE *spctxp, char *cmd, int cmdlen, 
     set_ctrlt_ast(sp_show_subprocess, *spctxp);
 
     cp = cmd;
-    while (cmdlen > 254) {
+    while (cmdlen > MMK_S_DCL) {
     	inquotes = 0;
-    	for (i = 0; i < 254; i++) {
+    	for (i = 0; i < MMK_S_DCL; i++) {
     	    if (cp[i] == '"') {
     	    	inquotes = !inquotes;
     	    	last_quote = i;
     	    }
     	}
-    	i = inquotes ? last_quote : 254;
+    	i = inquotes ? last_quote : MMK_S_DCL;
     	if (i == 0) {
     	    clear_ctrlt_ast();
     	    return MMK__CMDLENERR;

--- a/mmk.h
+++ b/mmk.h
@@ -57,6 +57,9 @@
 **  02-JUN-2012	    Sneddon	Update find_char definition. Remove MMK_S_MODULE.
 **  12-JUL-2012	    Sneddon	Add sp_once.
 **  13-JUL-2012	    Sneddon	Fix length for SDESC.
+**  14-JUL-2012	    Sneddon	Adjust testing for MMK_S_DCL depending on VMS
+**				 version.  Is based on WRK_C_INPBUFSIZ in
+**				 [DCL]DCLDEF.SDL (VMS source).
 */
 #ifndef mmk_h__
 #define mmk_h__
@@ -138,7 +141,11 @@ typedef struct { WORD bufsiz, itmcod; POINTER bufadr, retlen; } ITMLST;
 #if defined(__ALPHA) || defined(__ia64__)
 #define MMK_S_SFX       237     /* 235 + leading dot + trailing null */
 #define MMK_S_FILE      4096    /* 4095 is RMS limit, + trailing null */
-#define MMK_S_DCL	4097	/* 4096 is DCL command line + trailing null */
+#if __VMS_VER >= 70320022	/* OpenVMS Alpha V7.3-2 and higher has... */
+#define MMK_S_DCL	4097	/*  4096 is DCL command line + trailing null */
+#else				/* OpenVMS Alpha V7.3-1 and lower has... */
+#define MMK_S_DCL	256	/* 255 is DCL command line + trailing null */
+#endif
 #define MMK_S_MAXRSS	NAML$C_MAXRSS
 #else
 #define MMK_S_SFX       41      /* 39 + leading dot + trailing null */


### PR DESCRIPTION
of OpenVMS Alpha prior to V7.3-2.

The code to back it up has also been adjusted in the build_target module.

Thanks to Craig A. Berry for his contribution via the MMK-List mailing list.

This commit closes #1.
