### PR TITLE
Removed setting of flag SYNCHK from call to sys$parse.  This is a **bad*...

### DIFF
--- a/symbols.c
+++ b/symbols.c
@@ -3174,7 +3174,6 @@ static int apply_wildcard (int argc, struct dsc$descriptor *argv,
     nam.nam$b_ess = sizeof(esa);
     nam.nam$l_rsa = rsa;
     nam.nam$b_rss = sizeof(rsa);
-    nam.nam$b_nop = NAM$M_SYNCHK;
 #ifdef NAM$M_NO_SHORT_UPCASE
     nam.nam$b_nop |= NAM$M_NO_SHORT_UPCASE;
 #endif


### PR DESCRIPTION
...*

cut and paste bug!

This fixes #46.
