### PR TITLE
Update sp_mgr.c fix issue #103

### DIFF
--- a/sp_mgr.c
+++ b/sp_mgr.c
@@ -133,7 +133,7 @@
     static unsigned int sp_readattn_ast(SPHANDLE );
     static unsigned int try_to_send(SPHANDLE );
     static unsigned int send_completion(struct SPD *);
-    static unsigned int exit_handler(unsigned int *, struct QUE *);
+    static unsigned int sp_exit_handler(unsigned int *, struct QUE *);
     unsigned int sp_show_subprocess (SPHANDLE );
     static struct SPD *get_spd(int);
     static void free_spd(struct SPD *);
@@ -153,7 +153,7 @@
     	void *handler;
     	unsigned int argcnt;
     	void *p1, *p2;
-    } exhblk = {(struct EXH *) 0, (void *) exit_handler, 2,
+    } exhblk = {(struct EXH *) 0, (void *) sp_exit_handler, 2,
     	    	(void *)&exit_status, (void *) &spque};
 
 /*
@@ -756,7 +756,7 @@ static unsigned int send_completion (struct SPD *spd) {
 
 /*
 **++
-**  ROUTINE:	exit_handler
+**  ROUTINE:	sp_exit_handler
 **
 **  FUNCTIONAL DESCRIPTION:
 **
@@ -767,7 +767,7 @@ static unsigned int send_completion (struct SPD *spd) {
 **
 **  PROTOTYPE:
 **
-**  	exit_handler(unsigned int *stat, struct QUE *spq)
+**  	sp_exit_handler(unsigned int *stat, struct QUE *spq)
 **
 **  IMPLICIT INPUTS:	None.
 **
@@ -780,7 +780,7 @@ static unsigned int send_completion (struct SPD *spd) {
 **
 **--
 */
-static unsigned int exit_handler (unsigned int *stat, struct QUE *spq) {
+static unsigned int sp_exit_handler (unsigned int *stat, struct QUE *spq) {
 
     SPHANDLE ctx;
 
@@ -797,7 +797,7 @@ static unsigned int exit_handler (unsigned int *stat, struct QUE *spq) {
 
     return SS$_NORMAL;
 
-} /* exit_handler */
+} /* sp_exit_handler */
 
 /*
 **++
@@ -806,7 +806,7 @@ static unsigned int exit_handler (unsigned int *stat, struct QUE *spq) {
 **  FUNCTIONAL DESCRIPTION:
 **
 **  	Uses $GETJPI to get info on the subprocess and
-**  displays it à la CTRL/T.
+**  displays it Ã  la CTRL/T.
 **
 **  RETURNS:	cond_value, longword (unsigned), write only, by value
 **


### PR DESCRIPTION
Issue #103 describes the problem
The environment:

SYSTEM@x86vms$ mms /ident
%MMS-I-IDENT, MMS V4.0-4 ▒ Copyright 2022 VMS Software, Inc and Hewlett-Packard Development Company, L.P.
SYSTEM@x86vms$ cc /version
VSI C x86-64 X7.4-843 (GEM 50XB9) on OpenVMS x86_64 V9.2-1

Try to build with COMPILE.COM :

SYSTEM@x86vms$ @compile

MMK Bootstrap Procedure

$! If you have the SDL compiler installed, then feel free to uncomment the
$! lines below. However, it is not absolutely necessary as the resulting
$! header files are distributed with the source kit.
$!
 MESSAGE/NOOBJECT/SDL=MMK_MSG.SDL MMK_MSG.MSG
 SDL/VAX/LANGUAGE=CC=ETC_DIR:MMK_MSG.H MMK_MSG.SDL
$ LIBRARY/CREATE BIN_DIR:MMK.OLB
$ CC/NOLIST/OBJECT=BIN_DIR:MMK.OBJ MMK.C
$ LIBRARY/REPLACE BIN_DIR:MMK.OLB BIN_DIR:MMK.OBJ
$ CC/NOLIST/OBJECT=BIN_DIR:FILEIO.OBJ FILEIO.C
$ LIBRARY/REPLACE BIN_DIR:MMK.OLB BIN_DIR:FILEIO.OBJ
$ CC/NOLIST/OBJECT=BIN_DIR:MEM.OBJ MEM.C
$ LIBRARY/REPLACE BIN_DIR:MMK.OLB BIN_DIR:MEM.OBJ
$ CC/NOLIST/OBJECT=BIN_DIR:GET_RDT.OBJ GET_RDT.C
$ LIBRARY/REPLACE BIN_DIR:MMK.OLB BIN_DIR:GET_RDT.OBJ
$ CC/NOLIST/OBJECT=BIN_DIR:SP_MGR.OBJ SP_MGR.C
$ LIBRARY/REPLACE BIN_DIR:MMK.OLB BIN_DIR:SP_MGR.OBJ
%LIBRAR-E-DUPGLOBAL, global symbol exit_handler from file DKA0:[WORK.mmk.BIN-X86_64]SP_MGR.OBJ;1 already in library DKA0:[WORK.mmk.B
IN-X86_64]MMK.OLB;1
$BAIL_OUT:
$ EXIT 1.or.(0*F$VERIFY(0)) 

This is one of the simplest solution avoiding duplicate names in the library.
It builds and works well on OpenVMS x86_64