### PR TITLE
Fix quoting thinko in strip_comments

### DIFF
--- a/readdesc.c
+++ b/readdesc.c
@@ -343,12 +343,12 @@ static void strip_comments (char *dest, char *source) {
 
     quote = 0;
     for (cp = source; *cp; cp++) {
-    	if (quote) {
-    	    if (*cp == '"') quote = !quote;
-    	} else {
-	    if (*cp == '!' || *cp == '#') break;
-	}
-    	*cp1++ = *cp;
+        if (*cp == '"') {
+            quote = !quote;
+        } else {
+            if (!quote && (*cp == '!' || *cp == '#')) break;
+        }
+        *cp1++ = *cp;
     }
     while (cp1 > dest && isspace(*(cp1-1))) cp1--;
     *cp1 = 0;


### PR DESCRIPTION
The logic to only strip comments in unquoted text was not working because the boolean to toggle whether or not we were within a quote was never triggered.  A description file like this:

target :
	write sys$output "handle pound sign", \
" on continuation line # -- Still here after pound sign?"

would get everything after the pound sign ignored:

$ mmk target
write sys$output "handle pound sign", " on continuation line handle pound sign on continuation line

After this commit, the quoting is correctly recognized:

$ mmk target
write sys$output "handle pound sign", " on continuation line # -- Still here after pound sign?" handle pound sign on continuation line # -- Still here after pound sign?